### PR TITLE
16.0.0.2 - Drop-In Removed from POS

### DIFF
--- a/pos_hitpay/README.rst
+++ b/pos_hitpay/README.rst
@@ -86,6 +86,13 @@ Refunds
 
 Change Log
 ==========
+
+16.0.0.2
+--------------------
+* Feb 19, 2026
+* Removed drop-in codes since not required for the POS terminal.
+
 1.0.0.
 --------------------
+* Mar 23, 2024
 * Initial release.

--- a/pos_hitpay/__manifest__.py
+++ b/pos_hitpay/__manifest__.py
@@ -11,7 +11,7 @@
     'author': "HitPay Payment Solutions Pte Ltd",
     'website': "https://www.hitpayapp.com",
     'category': 'Sales/Point of Sale',
-    'version': '1.0.0',
+    'version': '16.0.2',
     'depends': ['base', 'point_of_sale'],
     'data': [
         'views/pos_payment_method_views.xml',
@@ -27,7 +27,6 @@
             'pos_hitpay/static/src/js/models.js',
         ],
 		'point_of_sale.assets': [
-			'https://hit-pay.com/hitpay.js',
             "pos_hitpay/static/src/xml/ReceiptScreen/OrderReceipt.xml",
 		],
     }

--- a/pos_hitpay/static/description/index.html
+++ b/pos_hitpay/static/description/index.html
@@ -130,5 +130,30 @@
     </div>
 </section>
 
+<section class="oe_container oe_dark">
+    <div class="oe_row oe_spaced">
+        <h2 class="oe_slogan" style="color:#875A7B;">Change Log</h2>
+        <div class="oe_span12 text-justify oe_mt32">
+            <ul class="list-unstyled" style="font-size:17px; border-radius:9px; padding-top:4px">
+				<li class="d-flex align-items-baseline mb-2">
+					<i class="fa fa-circle" style="font-size:15px; color:#113246; padding-right:9px"></i>
+					<span style="padding-bottom:3px">
+						<span style="text-decoration:underline">16.0.0.2</span><br/>
+						* Feb 19, 2026<br/>
+						* Removed drop-in codes since not required for the POS terminal.
+					</span>
+				</li>
+				<li class="d-flex align-items-baseline mb-2">
+					<i class="fa fa-circle" style="font-size:15px; color:#113246; padding-right:9px"></i><span style="padding-bottom:3px">
+						<span style="text-decoration:underline">1.0.0.1</span><br/>
+						* Mar 23, 2024<br/>
+						* Initial release.
+					</span>
+				</li>
+			</ul>
+        </div>
+    </div>
+</section>
+
 <section class="oe_container oe_separator">
 </section>

--- a/pos_hitpay/static/src/js/payment_hitpay_pos.js
+++ b/pos_hitpay/static/src/js/payment_hitpay_pos.js
@@ -212,41 +212,6 @@ odoo.define('pos_hitpay.payment', function (require) {
             }
             return Promise.resolve()
         } else if (response.id) {
-
-          let posHitpaySelf = self;
-          if (!window.HitPay.inited) {
-            window.HitPay.init(response.url, {
-              domain: response.domain,
-              apiDomain: response.api_domain,
-            },
-            {
-              onClose: function() {
-                const paymentLine = posHitpaySelf.get_selected_payment()
-                if (paymentLine) {
-                    paymentLine.set_payment_status(paymentStatus.RETRY)
-                }
-              },
-              onSuccess: function() {
-                const paymentLine = posHitpaySelf.get_selected_payment()
-                if (paymentLine) {
-                    paymentLine.setHitpayInvoiceId(response.id)
-                    paymentLine.set_payment_status(paymentStatus.WAITING)
-                }
-              },
-              onError: function(error) {
-                const paymentLine = posHitpaySelf.get_selected_payment()
-                if (paymentLine) {
-                    paymentLine.set_payment_status(paymentStatus.RETRY)
-                }
-                posHitpaySelf._show_error(_t('Payment Error. ')+error)
-              },
-            });
-          }
-
-          window.HitPay.toggle({
-              paymentRequest: response.id,          
-          });
-                            
           if (paymentLine) {
             paymentLine.setHitpayInvoiceId(response.id)
             paymentLine.set_payment_status(paymentStatus.WAITING)


### PR DESCRIPTION
16.0.0.2
--------------------
* Feb 19, 2026
* Removed drop-in codes since not required for the POS terminal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed HitPay Drop-In from POS. The POS no longer loads hitpay.js or opens the embedded modal; it creates the payment request and waits for status updates.

- **Refactors**
  - Removed Drop-In init/toggle logic from payment_hitpay_pos.js.
  - Removed external hitpay.js from point_of_sale.assets.
  - Bumped version to 16.0.2.
  - Updated README and app description with a changelog entry.

<sup>Written for commit c41a0606cad7a4813b1d2d32c73afb431d5737b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

