### PR TITLE
Post-Processing code is executed from the Webhook

### DIFF
--- a/payment_hitpay/README.rst
+++ b/payment_hitpay/README.rst
@@ -79,6 +79,13 @@ Refunds
 
 Change Log
 ==========
+
+16.0.0.2
+--------------------
+* Jun 09, 2026
+* Post-Processing code is executed from the Webhook to converts the quotation into a sales order when browser is closed before return URL and Quotation remains unconfirmed.
+
 1.0.
 --------------------
-* Initial release.
+* Jul 26, 2023
+* Initial release

--- a/payment_hitpay/__manifest__.py
+++ b/payment_hitpay/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': "HitPay Payment Gateway",
-    'version': '1.0',
+    'version': '16.0.0.2',
     'category': 'Accounting/Payment Providers',
     'sequence': 350,
     'summary': "HitPay Payment Gateway Plugin allows merchants to accept PayNow QR, Cards, Apple Pay, Google Pay, WeChatPay, AliPay and GrabPay Payments.",

--- a/payment_hitpay/models/payment_transaction.py
+++ b/payment_hitpay/models/payment_transaction.py
@@ -150,6 +150,10 @@ class PaymentTransaction(models.Model):
             self._set_pending(state_message=message)
         elif payment_status in TRANSACTION_STATUS_MAPPING['done']:
             self._set_done(state_message=message)
+            # Post-Processing code is executed from the Webhook to converts the quotation into a sales order.
+            # When browser is closed before return URL and Quotation remains unconfirmed.
+            self._finalize_post_processing()
+            
         elif payment_status in TRANSACTION_STATUS_MAPPING['canceled']:
             self._set_canceled()
         else:  # Classify unsupported payment status as the `error` tx state.

--- a/payment_hitpay/static/description/index.html
+++ b/payment_hitpay/static/description/index.html
@@ -118,5 +118,29 @@
     </div>
 </section>
 
+<section class="oe_container oe_dark">
+    <div class="oe_row oe_spaced">
+        <h2 class="oe_slogan" style="color:#875A7B;">Change Log</h2>
+        <div class="oe_span12 text-justify oe_mt32">
+            <ul class="list-unstyled" style="font-size:17px; border-radius:9px; padding-top:4px">
+				<li class="d-flex align-items-baseline mb-2">
+					<i class="fa fa-circle" style="font-size:15px; color:#113246; padding-right:9px"></i><span style="padding-bottom:3px">
+						<span style="text-decoration:underline">16.0.0.2</span><br/>
+						* Jun 09, 2026<br/>
+						* Post-Processing code is executed from the Webhook to converts the quotation into a sales order when browser is closed before return URL and Quotation remains unconfirmed.<br/>
+					</span>
+				</li>
+				<li class="d-flex align-items-baseline mb-2">
+					<i class="fa fa-circle" style="font-size:15px; color:#113246; padding-right:9px"></i><span style="padding-bottom:3px">
+						<span style="text-decoration:underline">1.0</span><br/>
+						* Jul 26, 2023<br/>
+						* Initial release.
+					</span>
+				</li>
+			</ul>
+        </div>
+    </div>
+</section>
+
 <section class="oe_container oe_separator">
 </section>


### PR DESCRIPTION
Post-Processing code is executed from the Webhook to converts the quotation into a sales order when browser is closed before return URL and Quotation remains unconfirmed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run order post‑processing from the HitPay webhook so a paid quotation is converted into a sales order even if the buyer closes the browser before the return URL. Prevents unconfirmed quotations after successful payment; bumps module to 16.0.0.2 and updates the changelog/docs.

<sup>Written for commit d97347cf6df816d2c9c9c5e1476f49f2a5f4e6ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/odoo-extension/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

