### PR TITLE
Subscription_Addon_19_Post_Launch_Polishing

### DIFF
--- a/payment_hitpay_subscription/README.rst
+++ b/payment_hitpay_subscription/README.rst
@@ -5,8 +5,8 @@ HitPay Subscription Payment Provider for Odoo 19 Enterprise
 =========================================================
 
 HitPay Subscription Payment Provider integrates HitPay Recurring Billing with
-Odoo Subscriptions, allowing merchants to securely collect recurring payments
-using saved customer payment methods.
+Odoo Subscriptions, allowing merchants to securely collect recurring subscription
+payments using saved customer payment methods.
 
 Customers authorize their payment method during the initial subscription
 checkout. Future subscription renewals are charged automatically using the
@@ -17,12 +17,13 @@ Features
 
 * Secure payment method tokenization
 * Automatic recurring subscription billing
+* Automatic subscription renewals
 * Online and offline token payments
-* Automatic recurring payment renewals
-* Automatic webhook registration and removal
+* Automatic webhook lifecycle management
 * Secure webhook signature verification
 * Automatic payment method attachment
 * Automatic payment method detachment
+* Saved payment methods for future payments
 * Intelligent provider visibility during checkout
 * Configurable recurring payment methods
 * Standalone payment provider for Odoo 19 Enterprise
@@ -30,8 +31,9 @@ Features
 Supported Recurring Payment Methods
 ===================================
 
-The payment methods displayed during checkout can be configured directly from
-Odoo based on the payment methods enabled in the merchant's HitPay account.
+Merchants can enable only the recurring payment methods supported by their
+HitPay account. Enabled payment methods are displayed automatically during
+checkout.
 
 Supported payment methods include:
 
@@ -64,7 +66,7 @@ Examples:
 * ``/var/lib/odoo/addons/<version>/``
 * Any directory configured in ``addons_path``
 
-Then update the Apps list and install:
+Update the Apps list and install:
 
 **HitPay Subscription Payment Provider**
 
@@ -75,21 +77,18 @@ Configuration
 
    **Accounting → Configuration → Payment Providers**
 
-2. Open **HitPay Subscription Payment Provider**
+2. Open **HitPay Subscription Payment Provider**.
 
 3. Enter your HitPay API credentials.
 
 4. Publish the payment provider.
 
-5. Configure the recurring payment methods you wish to offer.
+5. Enable the recurring payment methods supported by your HitPay account.
 
 6. Select an Accounting Journal.
 
-During installation the module automatically:
-
-* Registers the webhook with HitPay
-* Stores the webhook identifier
-* Stores the webhook event salt used for signature verification
+The module automatically manages the webhook throughout the payment provider
+lifecycle, including creation, updates, environment changes, and cleanup.
 
 Checkout Flow
 =============
@@ -100,46 +99,51 @@ Initial Subscription Payment
 1. Customer selects **HitPay Subscription** during checkout.
 2. Customer is redirected to the secure HitPay hosted payment page.
 3. Customer authorizes a recurring payment method.
-4. HitPay securely tokenizes the payment method.
-5. Odoo stores the payment token.
-6. The initial subscription payment is completed.
-7. The subscription becomes active.
+4. HitPay securely creates and authorizes the recurring payment method.
+5. Odoo automatically stores the payment token.
+6. Odoo performs the initial recurring subscription charge.
+7. The subscription payment is completed and the subscription becomes active.
 
 Recurring Renewals
 ------------------
 
 When the subscription is renewed:
 
-1. Odoo automatically creates the renewal invoice.
+1. Odoo automatically generates the renewal invoice.
 2. The saved payment method is charged automatically.
-3. Payment is registered in Odoo.
-4. The renewal invoice is paid automatically.
+3. The payment transaction is processed immediately.
+4. Payment is registered in Odoo.
+5. The renewal invoice is paid automatically.
 
 Webhook Processing
 ==================
 
-The module automatically processes the following webhook events:
+The module automatically processes the following recurring billing webhook
+events:
 
 * Payment method attached
 * Payment method detached
 
-Recurring payment transactions are processed synchronously from the immediate
-API response returned by HitPay. The ``charge.created`` webhook is acknowledged
-for auditing purposes but is not used for transaction processing.
+Recurring payment transactions are processed synchronously using the immediate
+API response returned by HitPay. Because HitPay does not provide a merchant
+reference when creating recurring charges, the ``charge.created`` webhook
+cannot be reliably correlated with an Odoo transaction. It is acknowledged for
+auditing purposes but is not used for transaction processing.
 
 Payment Method Lifecycle
 ========================
 
-When a customer authorizes a payment method:
+When a customer authorizes a recurring payment method:
 
 * A payment token is automatically created.
-* The HitPay recurring billing identifier is stored securely.
-* Future recurring charges reuse the same payment token.
+* The HitPay recurring billing identifier is securely stored.
+* The initial recurring subscription payment is processed automatically.
+* Future subscription renewals reuse the same saved payment token.
 
 If the customer removes the payment method from HitPay:
 
 * The corresponding Odoo payment token is automatically archived.
-* Future recurring payments using that token are prevented.
+* Future recurring payments using that payment token are prevented.
 
 Important Notes
 ===============
@@ -162,22 +166,22 @@ Odoo's standard invoicing rules.
 Supported Features
 ==================
 
-===============================  ===========
-Feature                          Support
-===============================  ===========
-Subscription Payments            Yes
-Payment Tokenization             Yes
-Saved Payment Methods            Yes
-Automatic Renewals               Yes
-Online Token Payments            Yes
-Offline Token Payments           Yes
-Webhook Registration             Yes
-Webhook Signature Verification   Yes
-Payment Method Attachment        Yes
-Payment Method Detachment        Yes
-Refunds                          No
-Express Checkout                 No
-===============================  ===========
+====================================  ===========
+Feature                               Support
+====================================  ===========
+Subscription Payments                 Yes
+Payment Tokenization                  Yes
+Saved Payment Methods                 Yes
+Automatic Subscription Renewals       Yes
+Online Token Payments                 Yes
+Offline Token Payments                Yes
+Automatic Webhook Lifecycle           Yes
+Webhook Signature Verification        Yes
+Payment Method Attachment             Yes
+Payment Method Detachment             Yes
+Refunds                               No
+Express Checkout                      No
+====================================  ===========
 
 Architecture
 ============
@@ -188,8 +192,8 @@ The module consists of:
 * Payment Transaction
 * Payment Token
 * Webhook Controller
-* Automatic Webhook Registration
-* Automatic Webhook Cleanup
+* Automatic Webhook Lifecycle Management
+* Odoo Subscription Integration
 
 License
 =======
@@ -210,13 +214,16 @@ Change Log
 
 19.0.0.1
 ---------
-
+* Jul 03, 2026
 * Initial release.
 * Standalone HitPay Subscription payment provider.
-* Secure payment tokenization.
+* Secure recurring payment method tokenization.
 * Automatic recurring subscription billing.
-* Automatic webhook registration and cleanup.
+* Automatic subscription renewals.
+* Online and offline token payments.
+* Automatic webhook lifecycle management.
 * Secure webhook signature verification.
 * Automatic payment method lifecycle management.
 * Configurable recurring payment methods.
 * Intelligent provider visibility during checkout.
+* Seamless integration with Odoo Subscriptions.

--- a/payment_hitpay_subscription/models/payment_provider.py
+++ b/payment_hitpay_subscription/models/payment_provider.py
@@ -20,7 +20,8 @@ class PaymentProvider(models.Model):
     _inherit = 'payment.provider'
 
     code = fields.Selection(
-        selection_add=[(const.PROVIDER_CODE, "HitPay Payment Gateway Subscription")], ondelete={const.PROVIDER_CODE: 'set default'}
+        selection_add=[(const.PROVIDER_CODE, "HitPay Payment Gateway Subscription")],
+        ondelete={const.PROVIDER_CODE: 'set default'}
     )
 
     hitpay_subscription_api_key = fields.Char(
@@ -42,6 +43,12 @@ class PaymentProvider(models.Model):
         copy=False,
         groups='base.group_system',
     )
+    
+    _WEBHOOK_TRIGGER_FIELDS  = {
+        "state",
+        "hitpay_subscription_api_key",
+        "hitpay_subscription_api_salt",
+    }
         
     def _ensure_webhook_event(self):
 
@@ -49,10 +56,7 @@ class PaymentProvider(models.Model):
 
         existing = self._get_existing_webhook()
 
-        if existing:
-            return existing
-
-        return self._create_webhook()    
+        return existing or self._create_webhook()   
         
     def _get_existing_webhook(self):
         self.ensure_one()
@@ -104,25 +108,43 @@ class PaymentProvider(models.Model):
 
         return event
 
-    def _delete_webhook(self):
+    def _delete_webhook(
+        self,
+        api_url=None,
+        api_key=None,
+        webhook_id=None,
+    ):
+        """
+        Optional api_url/api_key/webhook_id allow deleting a webhook
+        using the previous provider configuration when switching
+        between Test and Live environments.
+        """
+        
         self.ensure_one()
+        
+        api_url = api_url or self._get_api_url()
+        api_key = api_key or self.hitpay_subscription_api_key
+        webhook_id = webhook_id or self.hitpay_webhook_event_id
 
-        if not self.hitpay_webhook_event_id:
+        if not webhook_id:
             return
 
         try:
             self._hitpay_make_request(
-                f"/webhook-events/{self.hitpay_webhook_event_id}",
+                f"/webhook-events/{webhook_id}",
                 method="DELETE",
+                api_url=api_url,
+                api_key=api_key,
             )
             _logger.info(
                 "Deleted HitPay webhook event %s",
-                self.hitpay_webhook_event_id,
+                webhook_id,
             )
-        except ValidationError:
+        except ValidationError as e:
             _logger.warning(
-                "Failed to delete HitPay webhook event %s",
-                self.hitpay_webhook_event_id,
+                "Failed to delete HitPay webhook event %s. Reason: %s",
+                webhook_id,
+                str(e)
             )
             return
 
@@ -132,24 +154,34 @@ class PaymentProvider(models.Model):
         })
         
     def write(self, vals):
-        res = super().write(vals)
-
-        if "state" in vals and vals["state"] == "disabled":
-            disabled_providers = self.filtered(
-                lambda p: p.code == const.PROVIDER_CODE
-                and p.state == "disabled"
-            )
-
-            for provider in disabled_providers:
-                provider._delete_webhook()
-
-        watched = {
-            "state",
-            "hitpay_subscription_api_key",
-            "hitpay_subscription_api_salt",
+        old_values = {
+            provider.id: {
+                "api_url": provider._get_api_url(),
+                "api_key": provider.hitpay_subscription_api_key,
+                "webhook_id": provider.hitpay_webhook_event_id,
+                "state": provider.state,
+                
+            }
+            for provider in self
         }
 
-        if watched.intersection(vals):
+        res = super().write(vals)
+
+        if "state" in vals:
+            providers = self.filtered(
+                lambda p: p.code == const.PROVIDER_CODE
+            )
+
+            for provider in providers:
+                old_state = old_values[provider.id]["state"]
+                if old_state != provider.state:
+                    provider._delete_webhook(
+                        api_url=old_values[provider.id]["api_url"],
+                        api_key=old_values[provider.id]["api_key"],
+                        webhook_id=old_values[provider.id]["webhook_id"],
+                    )
+
+        if self._WEBHOOK_TRIGGER_FIELDS.intersection(vals):
             providers = self.filtered(
                 lambda p: p.code == const.PROVIDER_CODE
                 and p.state != "disabled"
@@ -189,10 +221,11 @@ class PaymentProvider(models.Model):
                     "Deleted HitPay webhook event %s",
                     data['webhook_id']
                 )
-            except Exception:
+            except Exception as e:
                 _logger.warning(
-                    "Failed to delete HitPay webhook event %s",
-                    data['webhook_id']
+                    "Failed to delete HitPay webhook event %s. Reason: %s",
+                    data['webhook_id'],
+                    str(e)
                 )
 
         return res
@@ -230,6 +263,8 @@ class PaymentProvider(models.Model):
         payload=None,
         method="POST",
         content_type=const.CONTENT_TYPE_FORM,
+        api_url=None,
+        api_key=None,
     ):
         """ Make a request to HitPay API at the specified endpoint.
 
@@ -244,9 +279,9 @@ class PaymentProvider(models.Model):
         """
         self.ensure_one()
 
-        url = self._get_api_url() + endpoint
+        url = (api_url or self._get_api_url()) + endpoint
 
-        headers = self._get_request_headers()
+        headers = self._get_request_headers(api_key=api_key)
         
         request_kwargs = {
             "headers": headers,
@@ -267,10 +302,9 @@ class PaymentProvider(models.Model):
         try:
 
             _logger.debug(
-                "[HitPay][%s] %s %s\n%s",
-                self.state,
+                "[HitPay] %s %s\n%s",
                 method,
-                endpoint,
+                url,
                 pprint.pformat(payload),
             )
 
@@ -283,23 +317,25 @@ class PaymentProvider(models.Model):
             try:
                 response_content = response.json()
             except ValueError:
-                response_content = {}
+                response_content = {
+                    "_raw_response": response.text
+                }
 
             _logger.debug(
                 "[HitPay][%s] Response %s\n%s",
-                self.state,
-                endpoint,
+                url,
                 pprint.pformat(response_content),
             )
             
             try:
                 response.raise_for_status()
                         
-            except requests.exceptions.HTTPError:
+            except requests.exceptions.HTTPError as e:
                 _logger.exception(
-                    "HitPay HTTP %s for %s",
+                    "HitPay HTTP %s for %s. Reason: %s",
                     response.status_code,
                     endpoint,
+                    str(e)
                 )
                 error_code = response_content.get('error')
                 error_message = response_content.get('message')
@@ -307,8 +343,8 @@ class PaymentProvider(models.Model):
                     "The communication with the API failed. HitPay Payment Gateway gave us the following "
                     "information: '%s' (code %s)", error_message, error_code
                 ))
-        except requests.exceptions.RequestException:
-            _logger.exception("Unable to reach endpoint at %s", url)
+        except requests.exceptions.RequestException as e:
+            _logger.exception("Unable to reach endpoint at %s. Reason: %s", url, str(e))
             self._raise_api_error(
                 "HitPay Subscription: " + _("Could not establish the connection to the API.")
             )
@@ -343,10 +379,10 @@ class PaymentProvider(models.Model):
             "event_types": list(const.WEBHOOK_EVENT_TYPES)
         }
         
-    def _get_request_headers(self):
+    def _get_request_headers(self, api_key=None):
         return {
             "X-Requested-With": "XMLHttpRequest",
-            "X-BUSINESS-API-KEY": self.hitpay_subscription_api_key,
+            "X-BUSINESS-API-KEY": api_key or self.hitpay_subscription_api_key,
         }
         
     def _raise_api_error(self, message):
@@ -389,9 +425,9 @@ class PaymentProvider(models.Model):
         if not sale_order_id:
             return providers
 
-        sale_order = self.env["sale.order"].browse(sale_order_id)
+        sale_order = self.env["sale.order"].browse(sale_order_id).exists()
 
-        if not sale_order.exists():
+        if not sale_order:
             return providers
         
         has_subscription = bool(

--- a/payment_hitpay_subscription/static/description/index.html
+++ b/payment_hitpay_subscription/static/description/index.html
@@ -28,9 +28,9 @@
 
             <p style="font-size:17px;">
                 The module automatically manages payment tokenization, recurring billing,
-                webhook registration, payment method lifecycle, and recurring subscription
-                payments while remaining fully integrated with the standard Odoo payment
-                framework.
+                automatic webhook lifecycle management, payment method lifecycle management,
+				and subscription renewals while remaining fully integrated with the standard 
+				Odoo payment framework.
             </p>
 
         </div>
@@ -47,25 +47,25 @@
 
             <ul class="list-unstyled" style="font-size:17px;">
 
-                <li>✔ Secure payment method tokenization.</li>
+                <li>&#10004; Secure payment method tokenization.</li>
 
-                <li>✔ Automatic recurring subscription billing.</li>
+                <li>&#10004; Automatic recurring subscription billing.</li>
 
-                <li>✔ Automatic webhook registration and removal.</li>
+                <li>&#10004; Automatic webhook lifecycle management.</li>
 
-                <li>✔ Secure webhook signature verification.</li>
+                <li>&#10004; Secure webhook signature verification.</li>
 
-                <li>✔ Automatic payment method attachment and detachment.</li>
+                <li>&#10004; Automatic payment method attachment and detachment.</li>
 
-                <li>✔ Saved payment methods for future payments.</li>
+                <li>&#10004; Saved payment methods for future payments.</li>
 
-                <li>✔ Online and offline token payments.</li>
+                <li>&#10004; Online and offline token payments.</li>
 
-                <li>✔ Configurable recurring payment methods.</li>
+                <li>&#10004; Configurable recurring payment methods.</li>
 
-                <li>✔ Intelligent provider visibility during checkout.</li>
+                <li>&#10004; Intelligent provider visibility during checkout.</li>
 
-                <li>✔ Standalone payment provider for Odoo 19 Enterprise.</li>
+                <li>&#10004; Standalone payment provider for Odoo 19 Enterprise.</li>
 
             </ul>
 
@@ -89,12 +89,12 @@
 
             <ul class="list-unstyled" style="font-size:17px;">
 
-                <li>• Visa</li>
-                <li>• Mastercard</li>
-                <li>• American Express</li>
-                <li>• GrabPay</li>
-                <li>• ShopeePay</li>
-                <li>• Touch 'n Go</li>
+                <li>&bull; Visa</li>
+                <li>&bull; Mastercard</li>
+                <li>&bull; American Express</li>
+                <li>&bull; GrabPay</li>
+                <li>&bull; ShopeePay</li>
+                <li>&bull; Touch 'n Go</li>
 
             </ul>
 
@@ -114,7 +114,7 @@
 
                 <li>1. Install the HitPay Subscription Payment Provider module.</li>
 
-                <li>2. Open <strong>Accounting → Configuration → Payment Providers</strong>.</li>
+                <li>2. Open <strong>Accounting &rarr; Configuration &rarr; Payment Providers</strong>.</li>
 
                 <li>3. Configure your HitPay API credentials.</li>
 
@@ -122,14 +122,14 @@
 
                 <li>5. Enable the recurring payment methods supported by your HitPay account.</li>
 
-                <li>6. The webhook is created automatically during module installation.</li>
+                <li>6. The webhook is managed automatically throughout the payment provider lifecycle.</li>
 
             </ul>
 
         </div>
 
         <div class="oe_span12">
-            <img class="oe_picture oe_screenshot" src="7-Configure-Credentials.png">
+            <!--img class="oe_picture oe_screenshot" src="1-Configure-Credentials.png"-->
         </div>
 
     </div>
@@ -150,11 +150,11 @@
 
                 <li>3. Customer authorizes a recurring payment method.</li>
 
-                <li>4. HitPay securely tokenizes the payment method.</li>
+                <li>4. HitPay securely creates and authorizes the recurring payment method.</li>
 
                 <li>5. Odoo automatically stores the payment token.</li>
 
-                <li>6. The initial subscription payment is completed.</li>
+                <li>6. Odoo performs the initial recurring subscription charge.</li>
 
                 <li>7. Future subscription renewals are charged automatically using the saved payment method.</li>
 
@@ -163,7 +163,7 @@
         </div>
 
         <div class="oe_span12">
-            <img class="oe_picture oe_screenshot" src="9-Frontend-Checkout-Page-Choose-Hitpay.png">
+            <!--img class="oe_picture oe_screenshot" src="2-Frontend-Checkout-Page-Choose-Hitpay.png"-->
         </div>
 
     </div>
@@ -177,25 +177,28 @@
         <div class="oe_span12 text-justify oe_mt32">
 
             <p style="font-size:17px;">
-                The module automatically handles HitPay recurring billing webhooks to manage
-                the payment method lifecycle.
+                The module automatically processes HitPay recurring billing webhooks to manage the 
+				payment method lifecycle and synchronize recurring payment methods with Odoo.
             </p>
 
             <ul class="list-unstyled" style="font-size:17px;">
 
-                <li>• Automatic payment method attachment.</li>
+                <li>&bull; Automatic payment method attachment.</li>
 
-                <li>• Automatic payment method detachment.</li>
+                <li>&bull; Automatic payment method detachment.</li>
 
-                <li>• Secure webhook signature verification.</li>
+                <li>&bull; Secure webhook signature verification.</li>
 
-                <li>• Automatic webhook lifecycle management.</li>
+                <li>&bull; Automatic webhook lifecycle management.</li>
 
             </ul>
 
             <p style="font-size:17px;">
-                Recurring payment transactions are processed synchronously using the immediate
-                API response returned by HitPay, ensuring reliable transaction processing.
+                The module securely processes recurring billing webhooks to manage payment
+				method attachment, detachment, and payment token lifecycle.
+				Recurring subscription payments are processed synchronously using the
+				immediate API response from HitPay, ensuring reliable transaction processing
+				without relying on asynchronous payment notifications.
             </p>
 
         </div>
@@ -242,37 +245,37 @@
 
                     <tr>
                         <td>Subscription Payments</td>
-                        <td>✔</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
                         <td>Payment Tokenization</td>
-                        <td>✔</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
                         <td>Automatic Subscription Renewal</td>
-                        <td>✔</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
                         <td>Saved Payment Methods</td>
-                        <td>✔</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
-                        <td>Webhook Registration</td>
-                        <td>✔</td>
+                        <td>Automatic Webhook Lifecycle</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
                         <td>Webhook Signature Verification</td>
-                        <td>✔</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
                         <td>Automatic Payment Method Lifecycle</td>
-                        <td>✔</td>
+                        <td>&#10004;</td>
                     </tr>
 
                     <tr>
@@ -305,24 +308,30 @@
 
                 <li>
                     <strong>Version 19.0.0.1</strong><br/>
+					
+					&bull; Jul 03, 2026<br/>
 
-                    • Initial release.<br/>
+                    &bull; Initial release.<br/>
 
-                    • Standalone HitPay Subscription payment provider.<br/>
+                    &bull; Standalone HitPay Subscription payment provider.<br/>
+					
+					&bull; Automatic recurring subscription billing.<br/>
 
-                    • Payment tokenization support.<br/>
+                    &bull; Secure recurring payment method tokenization.<br/>
+				
+					&bull; Online and offline token payments.<br/>
 
-                    • Automatic recurring subscription billing.<br/>
+                    &bull; Automatic webhook lifecycle management.<br/>
 
-                    • Automatic webhook registration and cleanup.<br/>
+                    &bull; Secure webhook signature verification.<br/>
 
-                    • Secure webhook signature verification.<br/>
+                    &bull; Automatic payment method lifecycle management.<br/>
 
-                    • Automatic payment method lifecycle management.<br/>
+                    &bull; Configurable recurring payment methods.<br/>
 
-                    • Configurable recurring payment methods.<br/>
-
-                    • Intelligent provider visibility during checkout.
+                    &bull; Intelligent provider visibility during checkout.<br/>
+					
+					&bull; Seamless integration with Odoo Subscriptions.
                 </li>
 
             </ul>


### PR DESCRIPTION
Description file updated for latin chars not displaying on the odoo marketplace
and delete_webhook bug issue is fixed when switch between the states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HitPay webhook cleanup when switching provider state or environments (Test/Live), preventing orphaned webhooks. Also updates marketplace description HTML to render symbols correctly by using HTML entities.

- **Bug Fixes**
  - Delete the previous webhook using old API URL/key and webhook ID when toggling state or switching environments; added optional params to `_delete_webhook`, captured old values in `write`, and unified triggers via `_WEBHOOK_TRIGGER_FIELDS`.
  - More robust request handling and logs: overrideable API URL/key, safer JSON parsing when responses aren’t JSON, clearer error messages, and `.exists()` guard in compatible provider lookup.
  - Replace Unicode symbols with HTML entities in `payment_hitpay_subscription/static/description/index.html` and refine `README.rst` copy to improve display on the Odoo Apps marketplace.

<sup>Written for commit 8e99c0b71b05201b2eefa34ec2989d5d0b64b1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/odoo-extension/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

